### PR TITLE
add fallback to 'sub' token claim

### DIFF
--- a/classes/loginflow/authcode.php
+++ b/classes/loginflow/authcode.php
@@ -372,6 +372,9 @@ class authcode extends base {
                 if (empty($upn)) {
                     $upn = $idtoken->claim('unique_name');
                 }
+
+                if (empty($upn)) {
+                    $upn = $idtoken->claim('sub');
             }
             $userrec = $DB->count_records_sql('SELECT COUNT(*)
                                                  FROM {user}


### PR DESCRIPTION
handlelogin() falls back to the token claim 'sub' if 'upn' and 'unique_name' are empty - I think this should happen in handleauthresponse() too.